### PR TITLE
Content and menu view controllers can be set by custom segues.

### DIFF
--- a/APLSlideMenu/APLSlideMenuSegue.h
+++ b/APLSlideMenu/APLSlideMenuSegue.h
@@ -1,0 +1,15 @@
+//  Created by Kay J. on 4.4.14.
+//  Copyright (c) 2012 apploft GmbH. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface APLSlideMenuLeftMenuSegue : UIStoryboardSegue
+@end
+
+@interface APLSlideMenuRightMenuSegue : UIStoryboardSegue
+@end
+
+@interface APLSlideMenuContentSegue : UIStoryboardSegue
+@end
+

--- a/APLSlideMenu/APLSlideMenuSegue.m
+++ b/APLSlideMenu/APLSlideMenuSegue.m
@@ -1,0 +1,42 @@
+//  Created by Kay J. on 4.4.14.
+//  Copyright (c) 2012 apploft GmbH. All rights reserved.
+//
+
+#import "APLSlideMenuSegue.h"
+#import "APLSlideMenuViewController.h"
+
+@implementation APLSlideMenuLeftMenuSegue
+
+- (void)perform {
+    APLSlideMenuViewController* slideMenuViewController = self.sourceViewController;
+    UIViewController* leftMenuViewController = self.destinationViewController;
+    
+    slideMenuViewController.leftMenuViewController = leftMenuViewController;
+}
+
+@end
+
+
+@implementation APLSlideMenuRightMenuSegue
+
+- (void)perform {
+    APLSlideMenuViewController* slideMenuViewController = self.sourceViewController;
+    UIViewController* rightMenuViewController = self.destinationViewController;
+    
+    slideMenuViewController.rightMenuViewController = rightMenuViewController;
+}
+
+@end
+
+
+@implementation APLSlideMenuContentSegue
+
+- (void)perform {
+    APLSlideMenuViewController* slideMenuViewController = self.sourceViewController;
+    UIViewController* contentViewController = self.destinationViewController;
+    
+    slideMenuViewController.contentViewController = contentViewController;
+}
+
+
+@end

--- a/APLSlideMenu/APLSlideMenuViewController.m
+++ b/APLSlideMenu/APLSlideMenuViewController.m
@@ -77,7 +77,7 @@ static CGFloat kAPLSlideMenuFirstOffset = 4.0;
     return self;
 }
 
-- (void)viewDidLoad {    
+- (void)viewDidLoad {
     [super viewDidLoad];
     
     //Create GestureRecognizers for NavigationView
@@ -93,6 +93,23 @@ static CGFloat kAPLSlideMenuFirstOffset = 4.0;
     self.contentContainerView = contentContainer;
     [self.view addSubview:contentContainer];
     [self addShadowToView:contentContainer];
+    
+    // Set left menu, right menu, and content view controller via story board.
+    @try {
+        [self performSegueWithIdentifier:@"content" sender:self];
+    }
+    @catch (NSException *exception) {
+    }
+    @try {
+        [self performSegueWithIdentifier:@"leftMenu" sender:self];
+    }
+    @catch (NSException *exception) {
+    }
+    @try {
+        [self performSegueWithIdentifier:@"rightMenu" sender:self];
+    }
+    @catch (NSException *exception) {
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated  {

--- a/APLSlideMenuDemo/APLSlideMenuDemo.xcodeproj/project.pbxproj
+++ b/APLSlideMenuDemo/APLSlideMenuDemo.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		B3FCC42C183A1C79005BF9D9 /* MainStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B3FCC42A183A1C79005BF9D9 /* MainStoryboard.storyboard */; };
 		B3FCC434183A2480005BF9D9 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = B3FCC432183A2480005BF9D9 /* InfoPlist.strings */; };
 		B3FCC441183A2509005BF9D9 /* APLSlideMenuViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B3FCC440183A2509005BF9D9 /* APLSlideMenuViewController.m */; };
+		B6A281FE18EEB2B200926904 /* APLSlideMenuSegue.m in Sources */ = {isa = PBXBuildFile; fileRef = B6A281FD18EEB2B200926904 /* APLSlideMenuSegue.m */; };
 		DD88AE3116809C51000412E1 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD88AE3016809C51000412E1 /* UIKit.framework */; };
 		DD88AE3316809C51000412E1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD88AE3216809C51000412E1 /* Foundation.framework */; };
 		DD88AE3516809C51000412E1 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD88AE3416809C51000412E1 /* CoreGraphics.framework */; };
@@ -40,6 +41,8 @@
 		B3FCC433183A2480005BF9D9 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = APLSlideMenuDemo/en.lproj/InfoPlist.strings; sourceTree = SOURCE_ROOT; };
 		B3FCC43F183A2509005BF9D9 /* APLSlideMenuViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APLSlideMenuViewController.h; sourceTree = "<group>"; };
 		B3FCC440183A2509005BF9D9 /* APLSlideMenuViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APLSlideMenuViewController.m; sourceTree = "<group>"; };
+		B6A281FC18EEB2B200926904 /* APLSlideMenuSegue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APLSlideMenuSegue.h; sourceTree = "<group>"; };
+		B6A281FD18EEB2B200926904 /* APLSlideMenuSegue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = APLSlideMenuSegue.m; sourceTree = "<group>"; };
 		DD88AE2D16809C51000412E1 /* APLSlideMenuDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = APLSlideMenuDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD88AE3016809C51000412E1 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		DD88AE3216809C51000412E1 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -67,6 +70,8 @@
 			children = (
 				B3FCC43F183A2509005BF9D9 /* APLSlideMenuViewController.h */,
 				B3FCC440183A2509005BF9D9 /* APLSlideMenuViewController.m */,
+				B6A281FC18EEB2B200926904 /* APLSlideMenuSegue.h */,
+				B6A281FD18EEB2B200926904 /* APLSlideMenuSegue.m */,
 			);
 			name = APLSlideMenu;
 			path = ../APLSlideMenu;
@@ -205,6 +210,7 @@
 				B3FCC410183A1B35005BF9D9 /* APLAppDelegate.m in Sources */,
 				B3FCC41D183A1BA6005BF9D9 /* main.m in Sources */,
 				B3FCC411183A1B35005BF9D9 /* APLMenuViewController.m in Sources */,
+				B6A281FE18EEB2B200926904 /* APLSlideMenuSegue.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/APLSlideMenuDemo/APLSlideMenuDemo.xcodeproj/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/APLSlideMenuDemo/APLSlideMenuDemo.xcodeproj/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -6,7 +6,7 @@
       <BreakpointProxy
          BreakpointExtensionID = "Xcode.Breakpoint.ExceptionBreakpoint">
          <BreakpointContent
-            shouldBeEnabled = "Yes"
+            shouldBeEnabled = "No"
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             scope = "0"

--- a/APLSlideMenuDemo/APLSlideMenuDemo/APLAppDelegate.m
+++ b/APLSlideMenuDemo/APLSlideMenuDemo/APLAppDelegate.m
@@ -14,19 +14,7 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
     // Override point for customization after application launch.
-    
-    id rootViewController = self.window.rootViewController;
-    if ([rootViewController isKindOfClass:[APLSlideMenuViewController class]]) {
-        APLSlideMenuViewController *slideViewController = rootViewController;
-        slideViewController.bouncing = YES;
-        slideViewController.menuWidth = 0.8;
-        slideViewController.gestureSupport = APLSlideMenuGestureSupportDrag;
-        slideViewController.leftMenuViewController = [[slideViewController storyboard] instantiateViewControllerWithIdentifier:@"Menu"];
-        slideViewController.contentViewController = [[slideViewController storyboard] instantiateViewControllerWithIdentifier:@"Content"];
-    } else {
-        NSLog(@"Ups, this shouldn't happen");
-    }
-    
+
     return YES;
 }
 							

--- a/APLSlideMenuDemo/APLSlideMenuDemo/APLViewController.h
+++ b/APLSlideMenuDemo/APLSlideMenuDemo/APLViewController.h
@@ -12,7 +12,8 @@
 
 @property (nonatomic, assign) IBOutlet UILabel *textLabel;
 
-- (IBAction)showMenu:(id)sender;
+- (IBAction)showLeftMenu:(id)sender;
+- (IBAction)showRightMenu:(id)sender;
 - (IBAction)gestureSupportChanged:(id)sender;
 
 @end

--- a/APLSlideMenuDemo/APLSlideMenuDemo/APLViewController.m
+++ b/APLSlideMenuDemo/APLSlideMenuDemo/APLViewController.m
@@ -18,7 +18,10 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+    
 	// Do any additional setup after loading the view, typically from a nib.
+    self.slideMenuController.bouncing = YES;
+    self.slideMenuController.gestureSupport = APLSlideMenuGestureSupportDrag;
 }
 
 - (void)didReceiveMemoryWarning
@@ -27,8 +30,12 @@
     // Dispose of any resources that can be recreated.
 }
 
-- (void)showMenu:(id)sender {
+- (void)showLeftMenu:(id)sender {
     [self.slideMenuController showLeftMenu:YES];
+}
+
+- (void)showRightMenu:(id)sender {
+    [self.slideMenuController showRightMenu:YES];
 }
 
 - (IBAction)gestureSupportChanged:(UISegmentedControl*)sender {

--- a/APLSlideMenuDemo/APLSlideMenuDemo/en.lproj/MainStoryboard.storyboard
+++ b/APLSlideMenuDemo/APLSlideMenuDemo/en.lproj/MainStoryboard.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="4514" systemVersion="13A603" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="2">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5053" systemVersion="13C64" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="2">
     <dependencies>
         <deployment defaultVersion="1536" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
     </dependencies>
     <scenes>
         <!--Slide Menu View Controller-->
@@ -14,15 +14,20 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
+                    <connections>
+                        <segue destination="T0f-c6-agC" kind="custom" identifier="content" customClass="APLSlideMenuContentSegue" id="Pbm-Dr-fUx"/>
+                        <segue destination="eky-b4-jCJ" kind="custom" identifier="leftMenu" customClass="APLSlideMenuLeftMenuSegue" id="k8T-hu-4g8"/>
+                        <segue destination="bEv-Mi-WfJ" kind="custom" identifier="rightMenu" customClass="APLSlideMenuRightMenuSegue" id="EsJ-2L-EBu"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="28" y="29"/>
+            <point key="canvasLocation" x="7" y="29"/>
         </scene>
-        <!--Menu View Controller-->
+        <!--Left Menu View Controller-->
         <scene sceneID="iLx-Yc-6GR">
             <objects>
-                <viewController storyboardIdentifier="Menu" useStoryboardIdentifierAsRestorationIdentifier="YES" id="eky-b4-jCJ" customClass="APLMenuViewController" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LeftMenu" useStoryboardIdentifierAsRestorationIdentifier="YES" id="eky-b4-jCJ" userLabel="Left Menu View Controller" customClass="APLMenuViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="PKw-To-Eum">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -54,12 +59,12 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="XoI-52-wn8" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="424" y="-39"/>
+            <point key="canvasLocation" x="456" y="-643"/>
         </scene>
-        <!--View Controller-->
+        <!--Content View Controller-->
         <scene sceneID="TkZ-v8-ryK">
             <objects>
-                <viewController storyboardIdentifier="Content" useStoryboardIdentifierAsRestorationIdentifier="YES" id="T0f-c6-agC" customClass="APLViewController" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="Content" useStoryboardIdentifierAsRestorationIdentifier="YES" id="T0f-c6-agC" userLabel="Content View Controller" customClass="APLViewController" sceneMemberID="viewController">
                     <view key="view" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="fsA-td-I69">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -72,13 +77,23 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="8LZ-KY-lnT">
-                                <rect key="frame" x="110" y="64" width="102" height="44"/>
+                                <rect key="frame" x="105" y="46" width="110" height="44"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="showMenu">
+                                <state key="normal" title="show Left Menu">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <connections>
-                                    <action selector="showMenu:" destination="T0f-c6-agC" eventType="touchUpInside" id="SJv-CR-YjK"/>
+                                    <action selector="showLeftMenu:" destination="T0f-c6-agC" eventType="touchUpInside" id="6AT-xx-CUL"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="4wY-cj-GjR">
+                                <rect key="frame" x="101" y="83" width="120" height="44"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="show Right Menu">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="showRightMenu:" destination="T0f-c6-agC" eventType="touchUpInside" id="mwX-eJ-v5R"/>
                                 </connections>
                             </button>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="d4B-zi-50b">
@@ -89,7 +104,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ueb-xW-IHp">
-                                <rect key="frame" x="80" y="119" width="163" height="55"/>
+                                <rect key="frame" x="80" y="133" width="163" height="55"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
                                 <string key="text">or use a slide gesture
 -----------------&gt;</string>
@@ -126,7 +141,44 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ovD-NG-bOg" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="490" y="286"/>
+            <point key="canvasLocation" x="456" y="29"/>
+        </scene>
+        <!--Right Menu View Controller-->
+        <scene sceneID="gGN-kD-96i">
+            <objects>
+                <viewController storyboardIdentifier="RightMenu" useStoryboardIdentifierAsRestorationIdentifier="YES" id="bEv-Mi-WfJ" userLabel="Right Menu View Controller" customClass="APLMenuViewController" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="lIF-gb-EMT">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <prototypes>
+                            <tableViewCell contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="aCell" textLabel="ltH-kl-8bk" style="IBUITableViewCellStyleDefault" id="umK-J5-2gf">
+                                <rect key="frame" x="0.0" y="22" width="320" height="44"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="umK-J5-2gf" id="TBn-Dd-fmf">
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ltH-kl-8bk">
+                                            <rect key="frame" x="15" y="0.0" width="290" height="43"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
+                                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                            <color key="highlightedColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="bEv-Mi-WfJ" id="IZU-Ts-S2B"/>
+                            <outlet property="delegate" destination="bEv-Mi-WfJ" id="TdZ-mN-dqf"/>
+                        </connections>
+                    </tableView>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="WWu-jw-Yqn" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="456" y="713"/>
         </scene>
     </scenes>
     <simulatedMetricsContainer key="defaultSimulatedMetrics">


### PR DESCRIPTION
I added `APLSlideMenuContentSegue`,  `APLSlideMenuLeftMenuSegue`, and `APLSlideMenuRightMenuSegue`.

With these segues and storyboard file, no code is required for setting `contentViewController`, ... .

As there is no cocoa API which enumerates the segue names of view controller, each segue must be named `content`, `leftMenu`, and `rightMenu`.

Please update `README.md` file for this new feature. (My English is not so good to write a manual)
