### PR TITLE
Fix transition of the content view display with right menu

### DIFF
--- a/APLSlideMenu/APLSlideMenuViewController.m
+++ b/APLSlideMenu/APLSlideMenuViewController.m
@@ -356,7 +356,10 @@ static CGFloat kAPLSlideMenuFirstOffset = 4.0;
     contentViewController.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 
     CGRect currentFrame     = self.view.bounds;
-    currentFrame.origin.x   = currentFrame.size.width;
+    if(self.activeMenuViewController == self.rightMenuViewController)
+        currentFrame.origin.x   = -currentFrame.size.width;
+    else
+        currentFrame.origin.x   = currentFrame.size.width;
     self.contentContainerView.frame = currentFrame;
     [self.contentContainerView insertSubview:contentViewController.view atIndex:0];
     


### PR DESCRIPTION
The transition of the content view display was made from the right to the left, even when used a right side menu