### PR TITLE
Add APLSlideMenuGestureSupportBasicOnlyHorizontal

### DIFF
--- a/APLSlideMenu/APLSlideMenuViewController.h
+++ b/APLSlideMenu/APLSlideMenuViewController.h
@@ -10,7 +10,8 @@ typedef NS_ENUM(NSInteger,APLSlideMenuGestureSupportType) {
     APLSlideMenuGestureSupportNone = 0,
     APLSlideMenuGestureSupportBasic,
     APLSlideMenuGestureSupportDrag,
-    APLSlideMenuGestureSupportDragOnlyNavigationBar
+    APLSlideMenuGestureSupportDragOnlyNavigationBar,
+    APLSlideMenuGestureSupportBasicOnlyHorizontal // Only register horizontal drags
 };
 
 @class APLSlideMenuViewController;

--- a/APLSlideMenu/APLSlideMenuViewController.m
+++ b/APLSlideMenu/APLSlideMenuViewController.m
@@ -475,14 +475,21 @@ static CGFloat kAPLSlideMenuFirstOffset = 4.0;
             break;
         }
         case UIGestureRecognizerStateEnded: {            
-            if (self.gestureSupport == APLSlideMenuGestureSupportBasic) {
-                if (xTranslation > 0.0) {
+            if (self.gestureSupport == APLSlideMenuGestureSupportBasic ||
+                self.gestureSupport == APLSlideMenuGestureSupportBasicOnlyHorizontal) {
+
+                BOOL hasCorrectAngle = YES;
+                if (self.gestureSupport == APLSlideMenuGestureSupportBasicOnlyHorizontal) {
+                    CGFloat angle = ABS(atan2(translation.y, translation.x));
+                    hasCorrectAngle = angle < M_PI_4 || angle > 3 * M_PI_4;
+                }
+                if (xTranslation > 0.0 && hasCorrectAngle) {
                     if (self.leftMenuViewController && !self.isMenuViewVisible) {
                         [self showLeftMenu:YES];
                     } else {
                         [self hideMenu:YES];
                     }
-                } else if (xTranslation < 0.0) {
+                } else if (xTranslation < 0.0 && hasCorrectAngle) {
                     if (self.rightMenuViewController && !self.isMenuViewVisible) {
                         [self showRightMenu:YES];
                     } else {

--- a/APLSlideMenu/APLSlideMenuViewController.m
+++ b/APLSlideMenu/APLSlideMenuViewController.m
@@ -480,8 +480,7 @@ static CGFloat kAPLSlideMenuFirstOffset = 4.0;
 
                 BOOL hasCorrectAngle = YES;
                 if (self.gestureSupport == APLSlideMenuGestureSupportBasicOnlyHorizontal) {
-                    CGFloat angle = ABS(atan2(translation.y, translation.x));
-                    hasCorrectAngle = angle < M_PI_4 || angle > 3 * M_PI_4;
+                    hasCorrectAngle = ABS(translation.x) > ABS(translation.y);
                 }
                 if (xTranslation > 0.0 && hasCorrectAngle) {
                     if (self.leftMenuViewController && !self.isMenuViewVisible) {


### PR DESCRIPTION
APLSlideMenuGestureSupportBasic is pretty sensitive when used in conjunction with UIScrollViews. Scrolling in vertical direction causes the menu to open accidentally because only the translation's x component is considered. Hence introduce APLSlideMenuGestureSupportBasicOnlyHorizontal that fires only if the drag gesture was predominantly horizontal.